### PR TITLE
chore: add Text::CSV perl package to backend images

### DIFF
--- a/backend.dockerfile
+++ b/backend.dockerfile
@@ -73,6 +73,7 @@ RUN apt-get -o Acquire::Retries=3 update \
         libmime-lite-perl \
         libnet-sftp-foreign-perl \
         libmailtools-perl \
+        libtext-csv-perl \
         unzip \
         xsltproc \
         dnsutils \

--- a/dspace/backend.dockerfile
+++ b/dspace/backend.dockerfile
@@ -70,6 +70,7 @@ RUN apt-get -o Acquire::Retries=3 update \
         libmime-lite-perl \
         libnet-sftp-foreign-perl \
         libmailtools-perl \
+        libtext-csv-perl \
         libio-pty-perl \
         unzip \
         zip \


### PR DESCRIPTION
## Add `Text::CSV` Perl Package to Backend Images

### Summary
Adds the Debian package `libtext-csv-perl` to both backend Docker image variants so
Perl scripts that require `Text::CSV` work consistently in local/CI and deployment
image paths.

### Changes

- `backend.dockerfile`: add `libtext-csv-perl` to the Step 3 `apt-get install`
  dependency list.
- `dspace/backend.dockerfile`: add `libtext-csv-perl` to the Step 3 `apt-get install`
  dependency list.

### Notes

- Build verification: `make build` completed successfully on 2026-06-24.
- Smoke verification: not completed in this run because `make up` failed with a host
  port conflict (`0.0.0.0:8983` already allocated by `boxrunner-solr-1`).

